### PR TITLE
fix: dev-pipeline failing due to newer selenide version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       mvnArgs:
         type: string
-        default: '-Divy.engine.download.url=https://dev.axonivy.com/permalink/nightly-10/axonivy-engine.zip'
+        default: '-Divy.engine.download.url=https://dev.axonivy.com/permalink/nightly-11.2/axonivy-engine.zip'
         required: false
       
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       mvnArgs:
         type: string
-        default: '-Divy.engine.download.url=https://dev.axonivy.com/permalink/nightly-11.2/axonivy-engine.zip'
+        default: '-Divy.engine.download.url=https://dev.axonivy.com/permalink/nightly-11/axonivy-engine.zip'
         required: false
       
 

--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.axonivy.utils.docfactory</name>
+	<name>DocFactoryModules</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/aspose-barcode-demo-product/pom.xml
+++ b/aspose-barcode-demo-product/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.axonivy.utils.docfactory</groupId>
   <artifactId>aspose-barcode-demo-product</artifactId>
-  <version>10.0.11-SNAPSHOT</version>
+  <version>11.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <build>

--- a/aspose-barcode-demo-test/pom.xml
+++ b/aspose-barcode-demo-test/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.axonivy.utils.docfactory</groupId>
 	<artifactId>aspose-barcode-demo-test</artifactId>
-	<version>10.0.11-SNAPSHOT</version>
+	<version>11.3.0-SNAPSHOT</version>
 	<packaging>iar-integration-test</packaging>
 
 	<properties>

--- a/aspose-barcode-demo-test/pom.xml
+++ b/aspose-barcode-demo-test/pom.xml
@@ -7,8 +7,8 @@
 	<packaging>iar-integration-test</packaging>
 
 	<properties>
-		<project-build-plugin-version>10.0.14</project-build-plugin-version>
-		<web-tester.version>10.0.14</web-tester.version>
+		<project-build-plugin-version>11.3.0-SNAPSHOT</project-build-plugin-version>
+		<web-tester.version>11.3.0-SNAPSHOT</web-tester.version>
 	</properties>
 
 	<dependencies>

--- a/aspose-barcode-demo/pom.xml
+++ b/aspose-barcode-demo/pom.xml
@@ -6,7 +6,7 @@
   <version>10.0.11-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project-build-plugin-version>10.0.14</project-build-plugin-version>
+    <project-build-plugin-version>11.3.0-SNAPSHOT</project-build-plugin-version>
     <aspose.version>23.4</aspose.version>
   </properties>
   <dependencies>

--- a/aspose-barcode-demo/pom.xml
+++ b/aspose-barcode-demo/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy.utils.docfactory</groupId>
   <artifactId>aspose-barcode-demo</artifactId>
-  <version>10.0.11-SNAPSHOT</version>
+  <version>11.3.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
     <project-build-plugin-version>11.3.0-SNAPSHOT</project-build-plugin-version>

--- a/aspose-email-demo-product/pom.xml
+++ b/aspose-email-demo-product/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.axonivy.utils.docfactory</groupId>
   <artifactId>aspose-email-demo-product</artifactId>
-  <version>10.0.11-SNAPSHOT</version>
+  <version>11.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <build>

--- a/aspose-email-demo-test/pom.xml
+++ b/aspose-email-demo-test/pom.xml
@@ -7,8 +7,8 @@
 	<packaging>iar-integration-test</packaging>
 
 	<properties>
-		<project-build-plugin-version>10.0.14</project-build-plugin-version>
-		<web-tester.version>10.0.14</web-tester.version>
+		<project-build-plugin-version>11.3.0-SNAPSHOT</project-build-plugin-version>
+		<web-tester.version>11.3.0-SNAPSHOT</web-tester.version>
 	</properties>
 
 	<dependencies>

--- a/aspose-email-demo-test/pom.xml
+++ b/aspose-email-demo-test/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.axonivy.utils.docfactory</groupId>
 	<artifactId>aspose-email-demo-test</artifactId>
-	<version>10.0.11-SNAPSHOT</version>
+	<version>11.3.0-SNAPSHOT</version>
 	<packaging>iar-integration-test</packaging>
 
 	<properties>

--- a/aspose-email-demo/pom.xml
+++ b/aspose-email-demo/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy.utils.docfactory</groupId>
   <artifactId>aspose-email-demo</artifactId>
-  <version>10.0.11-SNAPSHOT</version>
+  <version>11.3.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
     <project-build-plugin-version>11.3.0-SNAPSHOT</project-build-plugin-version>

--- a/aspose-email-demo/pom.xml
+++ b/aspose-email-demo/pom.xml
@@ -6,7 +6,7 @@
   <version>10.0.11-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project-build-plugin-version>10.0.14</project-build-plugin-version>
+    <project-build-plugin-version>11.3.0-SNAPSHOT</project-build-plugin-version>
     <aspose.version>23.4</aspose.version>
   </properties>
   <dependencies>

--- a/doc-factory-demos-test/pom.xml
+++ b/doc-factory-demos-test/pom.xml
@@ -7,7 +7,7 @@
 	<packaging>iar-integration-test</packaging>
 
 	<properties>
-		<project-build-plugin-version>11.2.0</project-build-plugin-version>
+		<project-build-plugin-version>11.3.0-SNAPSHOT</project-build-plugin-version>
 		<web-tester.version>11.3.0-SNAPSHOT</web-tester.version>
 	</properties>
 

--- a/doc-factory-demos-test/pom.xml
+++ b/doc-factory-demos-test/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>com.axonivy.utils.docfactory</groupId>
 	<artifactId>doc-factory-demos-test</artifactId>
-	<version>10.0.11-SNAPSHOT</version>
+	<version>11.3.0-SNAPSHOT</version>
 	<packaging>iar-integration-test</packaging>
 
 	<properties>

--- a/doc-factory-demos-test/pom.xml
+++ b/doc-factory-demos-test/pom.xml
@@ -7,8 +7,8 @@
 	<packaging>iar-integration-test</packaging>
 
 	<properties>
-		<project-build-plugin-version>10.0.14</project-build-plugin-version>
-		<web-tester.version>10.0.14</web-tester.version>
+		<project-build-plugin-version>11.2.0</project-build-plugin-version>
+		<web-tester.version>11.2.1</web-tester.version>
 	</properties>
 
 	<dependencies>
@@ -22,12 +22,12 @@
 			<groupId>com.axonivy.ivy.webtest</groupId>
 			<artifactId>web-tester</artifactId>
 			<version>${web-tester.version}</version>
-		 	<scope>test</scope>
- 		</dependency>
- 		<dependency>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.codeborne</groupId>
 			<artifactId>selenide-proxy</artifactId>
-			<version>6.9.0</version>
+			<version>7.0.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/doc-factory-demos-test/pom.xml
+++ b/doc-factory-demos-test/pom.xml
@@ -8,7 +8,7 @@
 
 	<properties>
 		<project-build-plugin-version>11.2.0</project-build-plugin-version>
-		<web-tester.version>11.2.1</web-tester.version>
+		<web-tester.version>11.3.0-SNAPSHOT</web-tester.version>
 	</properties>
 
 	<dependencies>

--- a/doc-factory-demos-test/src_test/com/axon/docfactory/demos/WebTestApiExamplesIT.java
+++ b/doc-factory-demos-test/src_test/com/axon/docfactory/demos/WebTestApiExamplesIT.java
@@ -7,7 +7,6 @@ import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.open;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.FileNotFoundException;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -60,7 +59,7 @@ class WebTestApiExamplesIT {
   }
 
   @Test
-  void zipMultipleDocuments() throws FileNotFoundException {
+  void zipMultipleDocuments() throws Exception {
     open(EngineUrl.createProcessUrl("/DocFactoryDemos/16CD7829EF6B489B/start2.ivp"));
     var doc = Selenide.$$("button").find(exactText("Create Multiple Formats")).shouldBe(visible).download();
     assertThat(doc).hasName("Documents.zip");
@@ -86,7 +85,7 @@ class WebTestApiExamplesIT {
     $("iframe").shouldBe(visible);
   }
 
-  private void assertDownload(String process, String expectedFileName) throws FileNotFoundException {
+  private void assertDownload(String process, String expectedFileName) throws Exception {
     open(EngineUrl.createProcessUrl(DOC_DEMOS_BASE + process));
     var doc = $("#docLink").shouldBe(visible).download();
     assertThat(doc).hasName(expectedFileName);

--- a/doc-factory-demos-test/src_test/com/axon/docfactory/demos/WebTestSubprocessExamplesIT.java
+++ b/doc-factory-demos-test/src_test/com/axon/docfactory/demos/WebTestSubprocessExamplesIT.java
@@ -5,7 +5,6 @@ import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.open;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.time.Duration;
 
@@ -62,11 +61,11 @@ class WebTestSubprocessExamplesIT {
     assertDownload("start6.ivp", "DocWithNestedObject.pdf");
   }
 
-  private void assertDownload(String process, String expectedFileName) throws FileNotFoundException {
+  private void assertDownload(String process, String expectedFileName) throws Exception {
     open(EngineUrl.createProcessUrl(DOC_DEMOS_BASE + process));
     var doc = $("#docLink").shouldBe(visible).download(DownloadOptions.using(FileDownloadMode.PROXY)
             .withTimeout(Duration.ofSeconds(10))
-            .withFilter(FileFilters.withName(expectedFileName))); 
+            .withFilter(FileFilters.withName(expectedFileName)));
 
     assertThat(doc).hasName(expectedFileName);
     assertThat(doc.length() / 1024).isGreaterThan(15);

--- a/doc-factory-demos/pom.xml
+++ b/doc-factory-demos/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>com.axonivy.utils.docfactory</groupId>
 	<artifactId>doc-factory-demos</artifactId>
-	<version>10.0.11-SNAPSHOT</version>
+	<version>11.3.0-SNAPSHOT</version>
 	<packaging>iar</packaging>
 
 	<properties>

--- a/doc-factory-demos/pom.xml
+++ b/doc-factory-demos/pom.xml
@@ -7,7 +7,7 @@
 	<packaging>iar</packaging>
 
 	<properties>
-		<project-build-plugin-version>10.0.14</project-build-plugin-version>
+		<project-build-plugin-version>11.3.0-SNAPSHOT</project-build-plugin-version>
 	</properties>
 
 	<repositories>

--- a/doc-factory-doc/pom.xml
+++ b/doc-factory-doc/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.axonivy.utils.docfactory</groupId>
 	<artifactId>doc-factory-doc</artifactId>
 	<packaging>pom</packaging>
-	<version>10.0.11-SNAPSHOT</version>
+	<version>11.3.0-SNAPSHOT</version>
 	<name>Doc Factory</name>
 
 	<build>

--- a/doc-factory-product/pom.xml
+++ b/doc-factory-product/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>com.axonivy.utils.docfactory</groupId>
   <artifactId>doc-factory-product</artifactId>
-  <version>10.0.11-SNAPSHOT</version>
+  <version>11.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <build>

--- a/doc-factory-test/pom.xml
+++ b/doc-factory-test/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.axonivy.utils.docfactory</groupId>
   <artifactId>doc-factory-test</artifactId>
-  <version>10.0.11-SNAPSHOT</version>
+  <version>11.3.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   
   <properties>

--- a/doc-factory-test/pom.xml
+++ b/doc-factory-test/pom.xml
@@ -7,7 +7,7 @@
   <packaging>iar</packaging>
   
   <properties>
-    <project-build-plugin-version>10.0.14</project-build-plugin-version>
+    <project-build-plugin-version>11.3.0-SNAPSHOT</project-build-plugin-version>
     <pdfbox.version>2.0.28</pdfbox.version>
     <powermock2.version>2.0.9</powermock2.version>
   </properties>

--- a/doc-factory/pom.xml
+++ b/doc-factory/pom.xml
@@ -7,7 +7,7 @@
   <packaging>iar</packaging>
 
   <properties>
-    <project-build-plugin-version>10.0.14</project-build-plugin-version>
+    <project-build-plugin-version>11.3.0-SNAPSHOT</project-build-plugin-version>
     <aspose.version>23.4</aspose.version>
   </properties>
  

--- a/doc-factory/pom.xml
+++ b/doc-factory/pom.xml
@@ -3,7 +3,7 @@
   
   <groupId>com.axonivy.utils.docfactory</groupId>
   <artifactId>doc-factory</artifactId>
-  <version>10.0.11-SNAPSHOT</version>
+  <version>11.3.0-SNAPSHOT</version>
   <packaging>iar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	
 	<artifactId>com.axonivy.utils.docfactory</artifactId>
 	<groupId>doc-factory-modules</groupId>
-	<version>10.0.11-SNAPSHOT</version>
+	<version>11.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
 	<modules>


### PR DESCRIPTION
in addition to this change; I've also introduced a release/10 branch
I think we can no longer keep v10-web-tester and selenide7 in harmony: https://github.com/axonivy-market/doc-factory/tree/release/10.0
