### PR TITLE
MARP-113 replace all substitutions

### DIFF
--- a/doc-factory-doc/source/doc-factory/callable-processes.rst
+++ b/doc-factory-doc/source/doc-factory/callable-processes.rst
@@ -163,13 +163,13 @@ process file:
 
 The second one (writeDocumentWithOneDataClass) allows writing a single document
 with a template by providing a **CompositeObject (DataClass)**. Here is the
-description of this callable that you can find in the |ivy| process file:
+description of this callable that you can find in the Axon Ivy process file:
 
 .. figure:: /_static/images/callable-processes-3.png
 
 Other ones (writeDocumentWithMailMergeTable) allow writing a single document
 with a template that can contain merge mail with regions (tables). Here is the
-description of this callable that you can find in the |ivy| process file:
+description of this callable that you can find in the Axon Ivy process file:
 
 .. figure:: /_static/images/callable-processes-4.png
 
@@ -195,6 +195,6 @@ than one document with a list of **DocumentTemplate** objects. Each
 regions and mail merge with nested regions are now supported, because the
 DocumentTemplate Object encapsulates the necessary parameters to perform such
 merges (:ref:`DocumentTemplate <df-callable-processes-document-template>`). Here
-is the description of this callable that you can find in the |ivy| process file:
+is the description of this callable that you can find in the Axon Ivy process file:
 
 .. figure:: /_static/images/callable-processes-2.png

--- a/doc-factory-doc/source/doc-factory/demos.rst
+++ b/doc-factory-doc/source/doc-factory/demos.rst
@@ -1,6 +1,6 @@
 Demos
 =====
 
-In the DocFactoryDemos Project included in the DocFactory |ivy| Market artifact
-that is available in the |ivy-designer| Ivy Project Import, you will find
+In the DocFactoryDemos Project included in the DocFactory Axon Ivy Market artifact
+that is available in the Axon Ivy Designer Ivy Project Import, you will find
 several hands-on examples showing how to create documents with the DocFactory.  

--- a/doc-factory-doc/source/doc-factory/doc-factory-object.rst
+++ b/doc-factory-doc/source/doc-factory/doc-factory-object.rst
@@ -3,7 +3,7 @@
 Document Factory Object
 =======================
 
-We implemented the |ivy| DocFactory Object based on the commercial
+We implemented the Axon Ivy DocFactory Object based on the commercial
 Aspose Java API. To be able to allow developing other Document Factories that
 work the same way as this one, a DocFactory implementation should always
 extend the abstract class
@@ -21,7 +21,7 @@ public static method :code:`BaseDocFactory.getInstance()` returns such an
 object.
 
 Suppose you want to use your own implementation class of the **BaseDocFactory**.
-In that case, you have to set a special Java system property on the |ivy-engine|
+In that case, you have to set a special Java system property on the Axon Ivy Engine
 named **document.factory**. Its value is the fully qualified name of your
 DocFactory class, e.g., :code:`com.acme.docfactory.MyDocFactory`. The
 :code:`getInstance()` method of the **BaseDocFactory** will then return an

--- a/doc-factory-doc/source/doc-factory/mail-merging.rst
+++ b/doc-factory-doc/source/doc-factory/mail-merging.rst
@@ -110,7 +110,7 @@ regions and merge regions in general:
      in the same row as the first cell.
    * The names of the columns in the DataTable must match the merge field name.
      Unless you have specified mapped fields the merge will not be successful
-     for those fields whose names are different. In the |ivy| Implementation of
+     for those fields whose names are different. In the Axon Ivy Implementation of
      this feature we use the Dataclasses Class names as TableStart names and the
      Dataclasses attributes names as mergefields names (more information
      :ref:`here <mail-merge-nested-mapping>`).
@@ -127,7 +127,7 @@ The following picture shows the result of the mail merge with regions:
 
 .. _mail-merge-nested-mapping:
 
-The previous nested mail merge has been made by using List of |ivy| DataClasses
+The previous nested mail merge has been made by using List of Axon Ivy DataClasses
 built as follows:
 
 .. figure:: /_static/images/mail-merge-nested-4.png

--- a/doc-factory-doc/source/index.rst
+++ b/doc-factory-doc/source/index.rst
@@ -7,15 +7,15 @@ merge letters with the help of Microsoft Office Templates (:file:`.dot` or
 
 You can extend the DocFactory to cover your project requirements. At the
 moment, it is implemented with the commercial Java Library `Aspose
-<https://www.aspose.com>`_ that we ship with the |ivy| Platform.
+<https://www.aspose.com>`_ that we ship with the Axon Ivy Platform.
 
 .. tip::
 
    The DocFactory currently bundles the modules aspose-words, aspose-cells,
    aspose-pdf, aspose-slides. There are additional Aspose modules such as
-   aspose-barcode, aspose-ocr, aspose-diagram, that you can use in |ivy|. You
+   aspose-barcode, aspose-ocr, aspose-diagram, that you can use in Axon Ivy. You
    have to add these modules from the `Aspose repository
-   <https://repository.aspose.com/repo/com/aspose/>`_ to your |ivy| project and
+   <https://repository.aspose.com/repo/com/aspose/>`_ to your Axon Ivy project and
    call the Java API. You can find the complete documentation on the Aspose
    website at `Aspose <https://www.aspose.com>`_. 
 


### PR DESCRIPTION
Removed all substitutions in DocFactory documentation so there is no need for a substitution script.