### PR TITLE
MARP-1333 Missing setup path for README_DE.md

### DIFF
--- a/aspose-barcode-demo-product/zip.xml
+++ b/aspose-barcode-demo-product/zip.xml
@@ -11,7 +11,7 @@
             <directory>.</directory>
             <includes>
                 <include>product.json</include>
-                <include>README.md</include>
+                <include>README*.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>

--- a/aspose-email-demo-product/zip.xml
+++ b/aspose-email-demo-product/zip.xml
@@ -11,7 +11,7 @@
             <directory>.</directory>
             <includes>
                 <include>product.json</include>
-                <include>README.md</include>
+                <include>README*.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>

--- a/doc-factory-product/zip.xml
+++ b/doc-factory-product/zip.xml
@@ -11,7 +11,7 @@
             <directory>.</directory>
             <includes>
                 <include>product.json</include>
-                <include>README.md</include>
+                <include>README*.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>


### PR DESCRIPTION
Included README_DE.md in pom.xml and zip.xml